### PR TITLE
Add A5 example data

### DIFF
--- a/website/sf.bike.parking.a5.json
+++ b/website/sf.bike.parking.a5.json
@@ -1,0 +1,250 @@
+[
+  {
+    "pentagon": "1ae2f83800000000",
+    "count": 73
+  },
+  {
+    "pentagon": "1ae2f87800000000",
+    "count": 165
+  },
+  {
+    "pentagon": "1ae2f8e800000000",
+    "count": 145
+  },
+  {
+    "pentagon": "1ae2f8c800000000",
+    "count": 137
+  },
+  {
+    "pentagon": "1ae2f89800000000",
+    "count": 41
+  },
+  {
+    "pentagon": "1ae2f8d800000000",
+    "count": 154
+  },
+  {
+    "pentagon": "1ae2f84800000000",
+    "count": 199
+  },
+  {
+    "pentagon": "1ae2f85800000000",
+    "count": 211
+  },
+  {
+    "pentagon": "1ae2d28800000000",
+    "count": 84
+  },
+  {
+    "pentagon": "1ae2f81800000000",
+    "count": 42
+  },
+  {
+    "pentagon": "1ae2f5a800000000",
+    "count": 35
+  },
+  {
+    "pentagon": "1ae2f77800000000",
+    "count": 46
+  },
+  {
+    "pentagon": "1ae2f82800000000",
+    "count": 187
+  },
+  {
+    "pentagon": "1ae2f72800000000",
+    "count": 23
+  },
+  {
+    "pentagon": "1ae2f95800000000",
+    "count": 31
+  },
+  {
+    "pentagon": "1ae2f7e800000000",
+    "count": 36
+  },
+  {
+    "pentagon": "1ae2f86800000000",
+    "count": 147
+  },
+  {
+    "pentagon": "1ae2f9e800000000",
+    "count": 11
+  },
+  {
+    "pentagon": "1ae2f88800000000",
+    "count": 140
+  },
+  {
+    "pentagon": "1ae2f75800000000",
+    "count": 60
+  },
+  {
+    "pentagon": "1ae2f73800000000",
+    "count": 14
+  },
+  {
+    "pentagon": "1ae2f93800000000",
+    "count": 22
+  },
+  {
+    "pentagon": "1ae2f8b800000000",
+    "count": 54
+  },
+  {
+    "pentagon": "1ae2f74800000000",
+    "count": 80
+  },
+  {
+    "pentagon": "1ae2f90800000000",
+    "count": 16
+  },
+  {
+    "pentagon": "1ae2f59800000000",
+    "count": 20
+  },
+  {
+    "pentagon": "1ae2f6f800000000",
+    "count": 4
+  },
+  {
+    "pentagon": "1ae2f58800000000",
+    "count": 11
+  },
+  {
+    "pentagon": "1ae2f8f800000000",
+    "count": 26
+  },
+  {
+    "pentagon": "1ae2f71800000000",
+    "count": 5
+  },
+  {
+    "pentagon": "1ae2f5b800000000",
+    "count": 6
+  },
+  {
+    "pentagon": "1ae2fba800000000",
+    "count": 22
+  },
+  {
+    "pentagon": "1ae2f57800000000",
+    "count": 16
+  },
+  {
+    "pentagon": "1ae2f7b800000000",
+    "count": 32
+  },
+  {
+    "pentagon": "1ae2f91800000000",
+    "count": 3
+  },
+  {
+    "pentagon": "1ae2f7f800000000",
+    "count": 28
+  },
+  {
+    "pentagon": "1ae2d29800000000",
+    "count": 2
+  },
+  {
+    "pentagon": "1ae2f97800000000",
+    "count": 10
+  },
+  {
+    "pentagon": "1ae2f78800000000",
+    "count": 21
+  },
+  {
+    "pentagon": "1ae2f6e800000000",
+    "count": 2
+  },
+  {
+    "pentagon": "1ae2f79800000000",
+    "count": 9
+  },
+  {
+    "pentagon": "1ae2f51800000000",
+    "count": 27
+  },
+  {
+    "pentagon": "1ae2f7d800000000",
+    "count": 30
+  },
+  {
+    "pentagon": "1ae2f76800000000",
+    "count": 7
+  },
+  {
+    "pentagon": "1ae2f6d800000000",
+    "count": 2
+  },
+  {
+    "pentagon": "1ae2f70800000000",
+    "count": 1
+  },
+  {
+    "pentagon": "1ae2d22800000000",
+    "count": 14
+  },
+  {
+    "pentagon": "1ae2f52800000000",
+    "count": 9
+  },
+  {
+    "pentagon": "1ae2fb9800000000",
+    "count": 10
+  },
+  {
+    "pentagon": "1ae2fbb800000000",
+    "count": 2
+  },
+  {
+    "pentagon": "1ae2f9d800000000",
+    "count": 2
+  },
+  {
+    "pentagon": "1ae2f7a800000000",
+    "count": 4
+  },
+  {
+    "pentagon": "1ae2f54800000000",
+    "count": 8
+  },
+  {
+    "pentagon": "1ae2f92800000000",
+    "count": 11
+  },
+  {
+    "pentagon": "1ae2f98800000000",
+    "count": 5
+  },
+  {
+    "pentagon": "1ae2f55800000000",
+    "count": 4
+  },
+  {
+    "pentagon": "1ae2f50800000000",
+    "count": 6
+  },
+  {
+    "pentagon": "1ae2f53800000000",
+    "count": 1
+  },
+  {
+    "pentagon": "1ae2f94800000000",
+    "count": 3
+  },
+  {
+    "pentagon": "1ae2f96800000000",
+    "count": 1
+  },
+  {
+    "pentagon": "1ae2f80800000000",
+    "count": 2
+  },
+  {
+    "pentagon": "1ae2f9c800000000",
+    "count": 1
+  }
+]


### PR DESCRIPTION
SF bike parking dataset aggregated using A5 (processed 2520 points into 62 A5 cells at resolution 13)
<img width="731" alt="Screenshot 2025-05-11 at 15 03 05" src="https://github.com/user-attachments/assets/10b180d5-c4bb-47c9-a7fb-eee862407a07" />
